### PR TITLE
Allow setting offset in directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,9 @@ exports.install = function (Vue) {
     function handleClick(e) {
         e.preventDefault()
 
-        exports.scrollTo(this.value, 500, {
-            easing: exports.easing['ease']
+        exports.scrollTo(this.value.scrollTo, 500, {
+            easing: exports.easing['ease'],
+            offset: this.value.offset
         })
     }
 


### PR DESCRIPTION
The change to the implementation is:

```html
<a href="#" v-scroll-to="{ 'scrollTo': '#section-' + index, 'offset': -75 }" class="nav-link">{{ link.name }}</a>
```

Let me know what you think!

Closes https://github.com/rigor789/vue-scrollTo/issues/6