### PR TITLE
Passive listeners for scroll abort events

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -141,7 +141,7 @@ const scroller = () => {
 
         if (!diff) return;
 
-        _.on(container, abortEvents, abortFn);
+        _.on(container, abortEvents, abortFn, { passive: true });
 
         window.requestAnimationFrame(step);
     }


### PR DESCRIPTION
Chrome is whining in console about the wheel/mousewheel listeners not being passive, this should fix it.