### PR TITLE
Fix  webpage cannot scroll down in iOS webview

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -111,14 +111,14 @@ const scroller = () => {
     }
 
     function topLeft(element, top, left) {
-        element.scrollTop = top;
         element.scrollLeft = left;
+        element.scrollTop = top;
         if (element.tagName.toLowerCase() === "body") {
             // in firefox body.scrollTop doesn't scroll the page
             // thus if we are trying to scrollTop on a body tag
             // we need to scroll on the documentElement
-            document.documentElement.scrollTop = top;
             document.documentElement.scrollLeft = left;
+            document.documentElement.scrollTop = top;
         }
     }
 


### PR DESCRIPTION
Fix : when I tab the nav ,webpage cannot scroll down in inner webview of  QQ App for iOS.
