### PR TITLE
Fix scrolling inside container

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -152,13 +152,14 @@ const scroller = () => {
         x = options.x === undefined ? defaults.x : options.x;
         y = options.y === undefined ? defaults.y : options.y;
 
-        var cumulativeOffset = _.cumulativeOffset(element);
+        var cumulativeOffsetContainer = _.cumulativeOffset(container);
+        var cumulativeOffsetElement = _.cumulativeOffset(element);
 
         initialY = scrollTop(container);
-        targetY = cumulativeOffset.top - container.offsetTop + offset;
+        targetY = cumulativeOffsetElement.top - cumulativeOffsetContainer.top + offset;
 
         initialX = scrollLeft(container);
-        targetX = cumulativeOffset.left - container.offsetLeft + offset;
+        targetX = cumulativeOffsetElement.left - cumulativeOffsetContainer.left + offset;
 
         abort = false;
 


### PR DESCRIPTION
I tried to scroll inside container. When I called `$scrollTo` method inside component than it always scrolled to bottom of the container, even if element was on top of the container.

For example there is a list, which can display only three list items:

```html
<list>
  <list-item-1/>
  <list-item-2/>
  <list-item-3/>
  <list-item-4/>
  <list-item-5/>
  <list-item-6/>
</list>
```

```vue
<template>
    <list ref="list">
        <list-item v-for="(option, index) in items"
                   :ref="`listItem`"
                   :key="`item-${index}`"
                   @click="click(index)"/>
    </list>
</template>

<script lang="ts">
    // ...
    public click(index: number) {
        this.$scrollTo((this.$refs.listItem as Vue[])[intex].$el, {
            container: (this.$refs.list as Vue).$el,
            duration: 1
        })
    }
    // ...
</script>
```

When I click to `list-item-1` then `vue-scroll` scroll down to the bottom of list, because wrongly calculate container offset.