### PR TITLE
Allow a callback in offset option

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -155,6 +155,10 @@ const scroller = () => {
         var cumulativeOffsetContainer = _.cumulativeOffset(container);
         var cumulativeOffsetElement = _.cumulativeOffset(element);
 
+        if (typeof offset === "function") {
+            offset = offset();
+        }
+
         initialY = scrollTop(container);
         targetY = cumulativeOffsetElement.top - cumulativeOffsetContainer.top + offset;
 


### PR DESCRIPTION
This is a improvement to allow that a callback can be passed to offset option. 

For example: when you use a responsive navbar that have a different height dependent of you layout, you can return a dynamic value to offset.