### PR TITLE
Export scroller factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,18 @@ let easings = {
 }
 ```
 
+## Simultaneous Scrolling
+
+If you need to scroll multiple containers simultaneously, you can import the scroller factory directly and create multiple instances. (Using the default `scrollTo` methods allows for only one scroll action at a time for performance reasons.)
+
+```js
+import {scroller} from 'vue-scrollto/src/scrollTo'
+const firstScrollTo = scroller()
+const secondScrollTo = scroller()
+firstScrollTo('#el1')
+secondScrollTo('#el2')
+```
+
 ## License
 
 MIT

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -27,7 +27,7 @@ export function setDefaults(options) {
     defaults = Object.assign({}, defaults, options);
 }
 
-const scroller = () => {
+export const scroller = () => {
     let element; // element to scroll to
     let container; // container to scroll
     let duration; // duration of the scrolling

--- a/vue-scrollto.js
+++ b/vue-scrollto.js
@@ -57,7 +57,7 @@ function newtonRaphsonIterate (aX, aGuessT, mX1, mX2) {
  return aGuessT;
 }
 
-var index = function bezier (mX1, mY1, mX2, mY2) {
+var src = function bezier (mX1, mY1, mX2, mY2) {
   if (!(0 <= mX1 && mX1 <= 1 && 0 <= mX2 && mX2 <= 1)) {
     throw new Error('bezier x values must be in [0, 1] range');
   }
@@ -370,7 +370,7 @@ var scroller = function scroller() {
             easing = easings[easing] || easings["ease"];
         }
 
-        easingFn = index.apply(index, easing);
+        easingFn = src.apply(src, easing);
 
         if (!diffY && !diffX) return;
 


### PR DESCRIPTION
Very minor code change to export the `scroller` factory function. This allows power users to create multiple instances of the scrollTo method, which enables multiple containers to be simultaneously scrolled. 

Also updates README with instructions on getting simultaneous scrolling working. 

Closes #73 