### PR TITLE
Added onStart callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Vue.use(VueScrollTo, {
      easing: "ease",
      offset: 0,
      cancelable: true,
+     onStart: false,
      onDone: false,
      onCancel: false,
      x: false,
@@ -85,6 +86,7 @@ VueScrollTo.setDefaults({
     easing: "ease",
     offset: 0,
     cancelable: true,
+    onStart: false,
     onDone: false,
     onCancel: false,
     x: false,
@@ -110,6 +112,7 @@ If you need to customize the scrolling options, you can pass in an object litera
      easing: 'linear',
      offset: -200,
      cancelable: true
+     onStart: onStart,
      onDone: onDone,
      onCancel: onCancel,
      x: false,
@@ -133,6 +136,9 @@ var options = {
     easing: 'ease-in',
     offset: -60,
     cancelable: true,
+    onStart: function() {
+      // scrolling started
+    },
     onDone: function() {
       // scrolling is done
     },
@@ -181,6 +187,11 @@ The offset that should be applied when scrolling. This option accepts a callback
 Indicates if user can cancel the scroll or not.
 
 *Default:* `true`
+
+#### onStart
+A callback function that should be called when scrolling has started.
+
+*Default:* `noop`
 
 #### onDone 
 A callback function that should be called when scrolling has ended. 

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -17,6 +17,7 @@ let defaults = {
     easing: "ease",
     offset: 0,
     cancelable: true,
+    onStart: false,
     onDone: false,
     onCancel: false,
     x: false,
@@ -34,6 +35,7 @@ export const scroller = () => {
     let easing; // easing to be used when scrolling
     let offset; // offset to be added (subtracted)
     let cancelable; // indicates if user can cancel the scroll or not.
+    let onStart; // callback when scrolling is started
     let onDone; // callback when scrolling is done
     let onCancel; // callback when scrolling is canceled / aborted
     let x; // scroll on x axis
@@ -149,6 +151,7 @@ export const scroller = () => {
         cancelable = options.hasOwnProperty("cancelable")
             ? options.cancelable !== false
             : defaults.cancelable;
+        onStart = options.onStart || defaults.onStart;
         onDone = options.onDone || defaults.onDone;
         onCancel = options.onCancel || defaults.onCancel;
         x = options.x === undefined ? defaults.x : options.x;
@@ -183,6 +186,7 @@ export const scroller = () => {
         easingFn = BezierEasing.apply(BezierEasing, easing);
 
         if (!diffY && !diffX) return;
+        if (onStart) onStart();
 
         _.on(container, abortEvents, abortFn, { passive: true });
 

--- a/vue-scrollto.js
+++ b/vue-scrollto.js
@@ -218,6 +218,7 @@ var defaults$$1 = {
     easing: "ease",
     offset: 0,
     cancelable: true,
+    onStart: false,
     onDone: false,
     onCancel: false,
     x: false,
@@ -235,6 +236,7 @@ var scroller = function scroller() {
     var easing = void 0; // easing to be used when scrolling
     var offset = void 0; // offset to be added (subtracted)
     var cancelable = void 0; // indicates if user can cancel the scroll or not.
+    var onStart = void 0; // callback when scrolling is started
     var onDone = void 0; // callback when scrolling is done
     var onCancel = void 0; // callback when scrolling is canceled / aborted
     var x = void 0; // scroll on x axis
@@ -343,6 +345,7 @@ var scroller = function scroller() {
         easing = options.easing || defaults$$1.easing;
         offset = options.offset || defaults$$1.offset;
         cancelable = options.hasOwnProperty("cancelable") ? options.cancelable !== false : defaults$$1.cancelable;
+        onStart = options.onStart || defaults$$1.onStart;
         onDone = options.onDone || defaults$$1.onDone;
         onCancel = options.onCancel || defaults$$1.onCancel;
         x = options.x === undefined ? defaults$$1.x : options.x;
@@ -373,6 +376,7 @@ var scroller = function scroller() {
         easingFn = src.apply(src, easing);
 
         if (!diffY && !diffX) return;
+        if (onStart) onStart();
 
         _.on(container, abortEvents, abortFn, { passive: true });
 


### PR DESCRIPTION
Would be nice to also have `onStart` callback, called when scroll actually happens, that is, after testing for diff.

Lets say I need to do or not do something during scroll animation. For that I would set a variable
`animating = true`, before calling `scrollTo` and in `onDone` callback would set it back to 
`animating = false`.
However, this works only as long as there is a difference in current position and target element. If not, the `onDone` callback is never called and animating stays true forever.