### PR TITLE
Add element parameter to onStart and onDone callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ var options = {
     easing: 'ease-in',
     offset: -60,
     cancelable: true,
-    onStart: function() {
+    onStart: function(element) {
       // scrolling started
     },
-    onDone: function() {
+    onDone: function(element) {
       // scrolling is done
     },
     onCancel: function() {
@@ -189,12 +189,12 @@ Indicates if user can cancel the scroll or not.
 *Default:* `true`
 
 #### onStart
-A callback function that should be called when scrolling has started.
+A callback function that should be called when scrolling has started. Receives the target element as a parameter.
 
 *Default:* `noop`
 
 #### onDone 
-A callback function that should be called when scrolling has ended. 
+A callback function that should be called when scrolling has ended. Receives the target element as a parameter.
 
 *Default:* `noop`
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A callback function that should be called when scrolling has ended. Receives the
 *Default:* `noop`
 
 #### onCancel 
-A callback function that should be called when scrolling has been aborted by the user (user scrolled, clicked etc.).
+A callback function that should be called when scrolling has been aborted by the user (user scrolled, clicked etc.). Receives the abort event and the target element as parameters.
  
 *Default:* `noop`
 

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -113,7 +113,7 @@ export const scroller = () => {
 
         _.off(container, abortEvents, abortFn);
         if (abort && onCancel) onCancel(abortEv);
-        if (!abort && onDone) onDone();
+        if (!abort && onDone) onDone(element);
     }
 
     function topLeft(element, top, left) {
@@ -186,7 +186,7 @@ export const scroller = () => {
         easingFn = BezierEasing.apply(BezierEasing, easing);
 
         if (!diffY && !diffX) return;
-        if (onStart) onStart();
+        if (onStart) onStart(element);
 
         _.on(container, abortEvents, abortFn, { passive: true });
 

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -112,7 +112,7 @@ export const scroller = () => {
         timeStart = false;
 
         _.off(container, abortEvents, abortFn);
-        if (abort && onCancel) onCancel(abortEv);
+        if (abort && onCancel) onCancel(abortEv, element);
         if (!abort && onDone) onDone(element);
     }
 

--- a/vue-scrollto.js
+++ b/vue-scrollto.js
@@ -309,7 +309,7 @@ var scroller = function scroller() {
         timeStart = false;
 
         _.off(container, abortEvents, abortFn);
-        if (abort && onCancel) onCancel(abortEv);
+        if (abort && onCancel) onCancel(abortEv, element);
         if (!abort && onDone) onDone(element);
     }
 

--- a/vue-scrollto.js
+++ b/vue-scrollto.js
@@ -310,7 +310,7 @@ var scroller = function scroller() {
 
         _.off(container, abortEvents, abortFn);
         if (abort && onCancel) onCancel(abortEv);
-        if (!abort && onDone) onDone();
+        if (!abort && onDone) onDone(element);
     }
 
     function topLeft(element, top, left) {
@@ -376,7 +376,7 @@ var scroller = function scroller() {
         easingFn = src.apply(src, easing);
 
         if (!diffY && !diffX) return;
-        if (onStart) onStart();
+        if (onStart) onStart(element);
 
         _.on(container, abortEvents, abortFn, { passive: true });
 


### PR DESCRIPTION
I ran into a situation where I wanted to add a class to an element after it had been scrolled to. Adding the element as a param of the `onStart` and `onDone` callback feels like a good way to make this possible.