### PR TITLE
Fix CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn add vue-scrollto
 
 Directly include it in html:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/vue@2.2.4"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue-scrollto"></script>
 ```
 <p class="tip">

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ yarn add vue-scrollto
 
 Directly include it in html:
 ```html
-<script src="https://unpkg.com/vue@2.2.4"></script>
-<script src="https://unpkg.com/vue-scrollto"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.2.4"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue-scrollto"></script>
 ```
 <p class="tip">
     When including it in html, it will automatically call `Vue.use` and also set a `VueScrollTo` variable that you can use!


### PR DESCRIPTION
Replaces CDN links with [jsDelivr](https://www.jsdelivr.com/package/npm/vue-scrollto) which provides a minified file. It works in the same way as unpkg and also offers larger network (I changed the vue link too since they recommend using jsDelivr as well).