### PR TITLE
Add force parameter (allows to scroll only if element is not in view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Vue.use(VueScrollTo, {
      duration: 500,
      easing: "ease",
      offset: 0,
+     force: true,
      cancelable: true,
      onStart: false,
      onDone: false,
@@ -85,6 +86,7 @@ VueScrollTo.setDefaults({
     duration: 500,
     easing: "ease",
     offset: 0,
+    force: true,
     cancelable: true,
     onStart: false,
     onDone: false,
@@ -111,7 +113,8 @@ If you need to customize the scrolling options, you can pass in an object litera
      duration: 500,
      easing: 'linear',
      offset: -200,
-     cancelable: true
+     force: true,
+     cancelable: true,
      onStart: onStart,
      onDone: onDone,
      onCancel: onCancel,
@@ -135,6 +138,7 @@ var options = {
     container: '#container',
     easing: 'ease-in',
     offset: -60,
+    force: true,
     cancelable: true,
     onStart: function(element) {
       // scrolling started
@@ -182,6 +186,11 @@ The easing to be used when animating. Read more in the [Easing section](#easing-
 The offset that should be applied when scrolling. This option accepts a callback function since `v2.8.0`. 
 
 *Default:* `0`
+
+#### force
+Indicates if scrolling should be performed, even if the scroll target is already in view.
+
+*Default:* `true`
 
 #### cancelable
 Indicates if user can cancel the scroll or not.

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -165,17 +165,6 @@ export const scroller = () => {
         var cumulativeOffsetContainer = _.cumulativeOffset(container);
         var cumulativeOffsetElement = _.cumulativeOffset(element);
 
-        if (!force) {
-            const containerTop = container.scrollTop;
-            const containerBottom = containerTop + container.offsetHeight;
-            const elementTop = element.offsetTop;
-            const elementBottom = element.offsetTop + element.offsetHeight;
-
-            if (elementTop >= containerTop && elementBottom <= containerBottom) {
-                return;
-            }
-        }
-
         if (typeof offset === "function") {
             offset = offset();
         }
@@ -194,6 +183,16 @@ export const scroller = () => {
 
         diffY = targetY - initialY;
         diffX = targetX - initialX;
+
+        if (!force) {
+            const containerTop = initialY;
+            const containerBottom = containerTop + container.offsetHeight;
+            const elementTop = targetY;
+            const elementBottom = elementTop + element.offsetHeight;
+            if (elementTop >= containerTop && elementBottom <= containerBottom) {
+                return;
+            }
+        }
 
         if (typeof easing === "string") {
             easing = easings[easing] || easings["ease"];

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -16,6 +16,7 @@ let defaults = {
     duration: 500,
     easing: "ease",
     offset: 0,
+    force: true,
     cancelable: true,
     onStart: false,
     onDone: false,
@@ -34,6 +35,7 @@ export const scroller = () => {
     let duration; // duration of the scrolling
     let easing; // easing to be used when scrolling
     let offset; // offset to be added (subtracted)
+    let force; // force scroll, even if element is visible
     let cancelable; // indicates if user can cancel the scroll or not.
     let onStart; // callback when scrolling is started
     let onDone; // callback when scrolling is done
@@ -148,6 +150,9 @@ export const scroller = () => {
         duration = options.duration || defaults.duration;
         easing = options.easing || defaults.easing;
         offset = options.offset || defaults.offset;
+        force = options.hasOwnProperty("force")
+            ? options.force !== false
+            : defaults.force;
         cancelable = options.hasOwnProperty("cancelable")
             ? options.cancelable !== false
             : defaults.cancelable;
@@ -159,6 +164,17 @@ export const scroller = () => {
 
         var cumulativeOffsetContainer = _.cumulativeOffset(container);
         var cumulativeOffsetElement = _.cumulativeOffset(element);
+
+        if (!force) {
+            const containerTop = container.scrollTop;
+            const containerBottom = containerTop + container.offsetHeight;
+            const elementTop = element.offsetTop;
+            const elementBottom = element.offsetTop + element.offsetHeight;
+
+            if (elementTop >= containerTop && elementBottom <= containerBottom) {
+                return;
+            }
+        }
 
         if (typeof offset === "function") {
             offset = offset();


### PR DESCRIPTION
Refs #55 

I added a new parameter (`force`) to the options. It defaults to `true` and the behavior should be the same. If set to `false`, it only scrolls if the element is not in view (same as `scrollIntoView()` referenced in #55).

This should fix the first bullet in #55
IMO the second bullet can be done using the `offset` param.

Hope it's useful :)

cc @rigor789 