### PR TITLE
Fix SSR issue when global.window object exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const install = function(Vue, options) {
 if (typeof window !== "undefined" && window.Vue) {
     window.VueScrollTo = VueScrollTo;
     window.VueScrollTo.setDefaults = setDefaults;
-    Vue.use(install);
+    window.Vue.use(install);
 }
 
 VueScrollTo.install = install;

--- a/vue-scrollto.js
+++ b/vue-scrollto.js
@@ -464,7 +464,7 @@ var install = function install(Vue, options) {
 if (typeof window !== "undefined" && window.Vue) {
     window.VueScrollTo = VueScrollTo$1;
     window.VueScrollTo.setDefaults = setDefaults;
-    Vue.use(install);
+    window.Vue.use(install);
 }
 
 VueScrollTo$1.install = install;


### PR DESCRIPTION
This issue is actual when during SSR we use `global.window = { Vue }` for different workarounds.