### PR TITLE
Add parameter to offset callback function

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -166,7 +166,7 @@ export const scroller = () => {
         var cumulativeOffsetElement = _.cumulativeOffset(element);
 
         if (typeof offset === "function") {
-            offset = offset();
+            offset = offset(element, container);
         }
 
         initialY = scrollTop(container);

--- a/vue-scrollto.js
+++ b/vue-scrollto.js
@@ -378,7 +378,7 @@
       var cumulativeOffsetElement = _.cumulativeOffset(element);
 
       if (typeof offset === "function") {
-        offset = offset();
+        offset = offset(element, container);
       }
 
       initialY = scrollTop(container);


### PR DESCRIPTION
This pull request adds the parameters `element` and `container` to the `offset()` callback function.

Related: #79

It allows to further control the scroll position, for example centering the content:
```javascript
function centerContent (element) {
  const elHeight = element.clientHeight;
  const winHeight = window.innerHeight;
  let offset = 0;
  if (winHeight > elHeight) {
    offset = -(winHeight - elHeight) * 0.5;
  }
  return offset;
}

Vue.use(VueScrollTo,  {
  offset: centerContent,
});
```