### PR TITLE
Fix force:false issue with viewport scrolling

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -187,8 +187,15 @@ export const scroller = () => {
         diffX = targetX - initialX;
 
         if (!force) {
+            // When the container is the default (body) we need to use the viewport
+            // height, not the entire body height
+            const containerHeight =
+                container.tagName.toLowerCase() === "body"
+                    ? document.documentElement.clientHeight ||
+                      window.innerHeight
+                    : container.offsetHeight;
             const containerTop = initialY;
-            const containerBottom = containerTop + container.offsetHeight;
+            const containerBottom = containerTop + containerHeight;
             const elementTop = targetY;
             const elementBottom = elementTop + element.offsetHeight;
             if (

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -204,7 +204,7 @@ export const scroller = () => {
             ) {
                 // make sure to call the onDone callback even if there is no need to
                 // scroll the container. Fixes #111 (ref #118)
-                onDone(element);
+                if (onDone) onDone(element);
                 return;
             }
         }


### PR DESCRIPTION
Currently, if an item is out of the bottom of the viewport and we attempt to scroll to it with `force:false`, it will decide that the item is already in the container (`body`) and therefore will not scroll.  I have a small reproduction of this at https://codesandbox.io/s/vue-scrollto-issue-sx56v.

When not specifying a container, and thus defaulting to `body`, the container should be treated as the viewport, otherwise it will never scroll downward to the element.  I think this is what #55 was getting at as well so I didn't file a separate issue.

This also fixes #140 since I happened to notice that while making this change.