### PR TITLE
feat: add typescript bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "Adds a directive that listens for click events and scrolls to elements.",
   "main": "vue-scrollto.js",
+  "types": "vue-scrollto.d.ts",
   "keywords": [
     "vue",
     "vuejs",

--- a/vue-scrollto.d.ts
+++ b/vue-scrollto.d.ts
@@ -1,0 +1,36 @@
+import Vue, { DirectiveOptions, PluginObject } from "vue"
+
+type ElementDescriptor = Element | string
+
+export interface ScrollOptions {
+  container?: ElementDescriptor
+  duration?: number
+  easing?: string
+  offset?: number
+  force?: boolean
+  cancelable?: boolean
+  onStart?: false | ((element: Element) => any)
+  onDone?: false | ((element: Element) => any)
+  onCancel?: false | ((event: Event, element: Element) => any)
+  x?: boolean
+  y?: boolean
+}
+
+type ScrollToFunction = (
+  element: ElementDescriptor,
+  duration?: number,
+  options?: ScrollOptions,
+) => () => void
+
+declare const _default: PluginObject<ScrollOptions> &
+  DirectiveOptions & {
+    scrollTo: ScrollToFunction
+  }
+
+export default _default
+
+declare module "vue/types/vue" {
+  interface Vue {
+    $scrollTo: ScrollToFunction
+  }
+}


### PR DESCRIPTION
Add Typescript bindings. Without it, typescript projects will show errors:

![image](https://user-images.githubusercontent.com/128121/64944095-b03d9d00-d897-11e9-8a1d-a8296d901ce5.png)
