### PR TITLE
Added better types for typescript

### DIFF
--- a/vue-scrollto.d.ts
+++ b/vue-scrollto.d.ts
@@ -1,36 +1,39 @@
-import Vue, { DirectiveOptions, PluginObject } from "vue"
+import {DirectiveOptions, PluginObject} from "vue"
 
 type ElementDescriptor = Element | string
 
 export interface ScrollOptions {
-  container?: ElementDescriptor
-  duration?: number
-  easing?: string
-  offset?: number
-  force?: boolean
-  cancelable?: boolean
-  onStart?: false | ((element: Element) => any)
-  onDone?: false | ((element: Element) => any)
-  onCancel?: false | ((event: Event, element: Element) => any)
-  x?: boolean
-  y?: boolean
+    el?: ElementDescriptor;
+    element?: ElementDescriptor;
+    container?: ElementDescriptor;
+    duration?: number;
+    easing?: string | [number, number, number, number];
+    offset?: number | ((element: ElementDescriptor, container: ElementDescriptor) => number);
+    force?: boolean;
+    cancelable?: boolean;
+    onStart?: ((element: Element) => any) | false;
+    onDone?: ((element: Element) => any) | false;
+    onCancel?: ((event: Event, element: Element) => any) | false;
+    x?: boolean;
+    y?: boolean;
 }
 
-type ScrollToFunction = (
-  element: ElementDescriptor,
-  duration?: number,
-  options?: ScrollOptions,
-) => () => void
+type ScrollToFunction = {
+    (options: ScrollOptions): void;
+    (element: ElementDescriptor, options?: ScrollOptions): void;
+    (element: ElementDescriptor, duration: number, options?: ScrollOptions): void;
+}
 
 declare const _default: PluginObject<ScrollOptions> &
-  DirectiveOptions & {
+    DirectiveOptions & {
     scrollTo: ScrollToFunction
-  }
+    setDefaults: ScrollToFunction;
+};
 
 export default _default
 
 declare module "vue/types/vue" {
-  interface Vue {
-    $scrollTo: ScrollToFunction
-  }
+    interface Vue {
+        $scrollTo: ScrollToFunction
+    }
 }

--- a/vue-scrollto.d.ts
+++ b/vue-scrollto.d.ts
@@ -19,9 +19,9 @@ export interface ScrollOptions {
 }
 
 type ScrollToFunction = {
-    (options: ScrollOptions): void;
-    (element: ElementDescriptor, options?: ScrollOptions): void;
-    (element: ElementDescriptor, duration: number, options?: ScrollOptions): void;
+    (options: ScrollOptions): () => void;
+    (element: ElementDescriptor, options?: ScrollOptions): () => void;
+    (element: ElementDescriptor, duration: number, options?: ScrollOptions): () => void;
 }
 
 declare const _default: PluginObject<ScrollOptions> &


### PR DESCRIPTION
Added possibility to use:

```
import VueScrollTo from "vue-scrollto";

VueScrollTo.scrollTo(element.$el, {offset: -125, duration: 1});
```