### PR TITLE
Do nothing when ctx.value is empty

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -39,8 +39,10 @@ function getBinding(el) {
 }
 
 function handleClick(e) {
+  const ctx = getBinding(this).binding
+  if (!ctx.value) return
+
   e.preventDefault()
-  let ctx = getBinding(this).binding
 
   if (typeof ctx.value === 'string') {
     return scrollTo(ctx.value)


### PR DESCRIPTION
If `ctx.value` is `undefined` or `null` (or any falsy value) the developer doesn't want to scroll.

So don't `preventDefault` and do nothing and let the default to do its work.