### PR TITLE
Fixed options offset equals zero was't recognized

### DIFF
--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -145,7 +145,7 @@ export const scroller = () => {
     container = _.$(options.container || defaults.container)
     duration = options.duration || defaults.duration
     easing = options.easing || defaults.easing
-    offset = options.offset || defaults.offset
+    offset = options.hasOwnProperty('offset') ? options.offset : defaults.offset
     force = options.hasOwnProperty('force')
       ? options.force !== false
       : defaults.force


### PR DESCRIPTION
This PR fixes the bug that the default value will be used if the options offset value was set to zero.

Example:
```
import VueScrollTo from 'vue-scrollto';

Vue.use(VueScrollTo, {
  offset: -30
});
```

```
this.$scrollTo('#idToScroll', { offset: 0 });
```