### PR TITLE
feat: add lazy option to allow recalculating targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In case you are using the browser version (directly including the script on your
 VueScrollTo.setDefaults({
     container: "body",
     duration: 500,
-    dynamicPosition: true,
+    lazy: false,
     easing: "ease",
     offset: 0,
     force: true,
@@ -126,7 +126,7 @@ If you need to customize the scrolling options, you can pass in an object litera
      el: '#element',
      container: '#container',
      duration: 500,
-     dynamicPosition: true
+     lazy: false
      easing: 'linear',
      offset: -200,
      force: true,
@@ -153,7 +153,7 @@ var VueScrollTo = require('vue-scrollto');
 var options = {
     container: '#container',
     easing: 'ease-in',
-    dynamicPosition: true,
+    lazy: false,
     offset: -60,
     force: true,
     cancelable: true,
@@ -194,15 +194,15 @@ The duration (in milliseconds) of the scrolling animation.
 
 *Default:* `500` 
 
-#### dynamicPosition
-Recalculating targetY/targetX at each scroll step. Useful when you don't know the final height of the container, and it grows as it scrolls.
-
-*Default:* `false` 
-
 #### easing 
 The easing to be used when animating. Read more in the [Easing section](#easing-detailed). 
 
 *Default:* `ease`
+
+#### lazy
+Recalculating targetY/targetX at each scroll step. Useful when you don't know the final height of the container, and it grows as it scrolls.
+
+*Default:* `true` 
 
 #### offset 
 The offset that should be applied when scrolling. This option accepts a callback function since `v2.8.0`. 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ In case you are using the browser version (directly including the script on your
 VueScrollTo.setDefaults({
     container: "body",
     duration: 500,
+    dynamicPosition: true,
     easing: "ease",
     offset: 0,
     force: true,
@@ -125,6 +126,7 @@ If you need to customize the scrolling options, you can pass in an object litera
      el: '#element',
      container: '#container',
      duration: 500,
+     dynamicPosition: true
      easing: 'linear',
      offset: -200,
      force: true,
@@ -151,6 +153,7 @@ var VueScrollTo = require('vue-scrollto');
 var options = {
     container: '#container',
     easing: 'ease-in',
+    dynamicPosition: true,
     offset: -60,
     force: true,
     cancelable: true,
@@ -190,6 +193,11 @@ The container that has to be scrolled.
 The duration (in milliseconds) of the scrolling animation. 
 
 *Default:* `500` 
+
+#### dynamicPosition
+Recalculating targetY/targetX at each scroll step. Useful when you don't know the final height of the container, and it grows as it scrolls.
+
+*Default:* `false` 
 
 #### easing 
 The easing to be used when animating. Read more in the [Easing section](#easing-detailed). 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The easing to be used when animating. Read more in the [Easing section](#easing-
 *Default:* `ease`
 
 #### lazy
-Recalculating targetY/targetX at each scroll step. Useful when you don't know the final height of the container, and it grows as it scrolls.
+By default targetX/targetY are calculated once at the start of a scroll, however if the target may shift around during the scroll - setting `lazy` to `false` will force recalculation of targetX/targetY at each scroll step.
 
 *Default:* `true` 
 

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -35,7 +35,7 @@ export const scroller = () => {
   let container // container to scroll
   let duration // duration of the scrolling
   let easing // easing to be used when scrolling
-  let lazy //checks the target position at each step
+  let lazy // checks the target position at each step
   let offset // offset to be added (subtracted)
   let force // force scroll, even if element is visible
   let cancelable // indicates if user can cancel the scroll or not.

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -193,15 +193,13 @@ export const scroller = () => {
       offset = offset(element, container)
     }
 
-    initialY = scrollTop(container)
     initialX = scrollLeft(container)
+    initialY = scrollTop(container)
 
+    // calculates cumulative offsets and targetX/Y + diffX/Y
     recalculateTargets()
 
     abort = false
-
-    diffY = targetY - initialY
-    diffX = targetX - initialX
 
     if (!force) {
       // When the container is the default (body) we need to use the viewport


### PR DESCRIPTION
Hello!
I ran into a problem when I was trying to use this lib on a dynamically growing container. Figuratively speaking, at the start of the scroll, the height of the container was 500px, and at the end it could reach 5000px. Thus, the initially set position was strongly shifted down, but the scrollTo did not know about this and scrolled to the wrong place. This PR solves this problem.