### PR TITLE
preserveId option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Vue.use(VueScrollTo, {
      onCancel: false,
      x: false,
      y: true
+     preserveId: false,
  })
 ```
 
@@ -109,6 +110,7 @@ VueScrollTo.setDefaults({
     onCancel: false,
     x: false,
     y: true
+    preserveId: false,
 })
 ```
 
@@ -137,6 +139,7 @@ If you need to customize the scrolling options, you can pass in an object litera
      onCancel: onCancel,
      x: false,
      y: true
+     preserveId: false,
  }">
     Scroll to #element
 </a>
@@ -169,6 +172,7 @@ var options = {
     },
     x: false,
     y: true
+    preserveId: false,
 }
 
 var cancelScroll = VueScrollTo.scrollTo(element, duration, options)
@@ -245,6 +249,10 @@ Whether or not we want scrolling on the `y` axis
  
 *Default:* `true`
 
+#### preserveId
+Indicates if hash scrolling update url with the target id or not.
+
+*Default:* `false`
 
 <h2 id="easing-detailed">Easing</h2>
 

--- a/src/scrollTo.js
+++ b/src/scrollTo.js
@@ -24,6 +24,7 @@ let defaults = {
   onCancel: false,
   x: false,
   y: true,
+  preserveId: false,
 }
 
 export function setDefaults(options) {
@@ -44,6 +45,7 @@ export const scroller = () => {
   let onCancel // callback when scrolling is canceled / aborted
   let x // scroll on x axis
   let y // scroll on y axis
+  let preserveId // preserve element's id in url hash
 
   let initialX // initial X of container
   let targetX // target X of container
@@ -188,6 +190,10 @@ export const scroller = () => {
     onCancel = options.onCancel || defaults.onCancel
     x = options.x === undefined ? defaults.x : options.x
     y = options.y === undefined ? defaults.y : options.y
+    preserveId =
+      options.preserveId === undefined
+        ? defaults.preserveId
+        : options.preserveId
 
     if (typeof offset === 'function') {
       offset = offset(element, container)
@@ -220,6 +226,8 @@ export const scroller = () => {
       }
     }
 
+    if (preserveId && target.startsWith('#'))
+      window.history.pushState(null, '', `#${element.id}`)
     if (onStart) onStart(element)
 
     if (!diffY && !diffX) {

--- a/vue-scrollto.d.ts
+++ b/vue-scrollto.d.ts
@@ -16,6 +16,7 @@ export interface ScrollOptions {
     onCancel?: ((event: Event, element: Element) => any) | false;
     x?: boolean;
     y?: boolean;
+    preserveId?: boolean
 }
 
 type ScrollToFunction = {


### PR DESCRIPTION
# this resolves #85

- add `preserveId` option (default: `false`)
  - this updates the hash param in the url before calling `onStart`